### PR TITLE
fix env var name SWIYU_STATUS_REGISTRY_API_URL

### DIFF
--- a/sample.compose.yml
+++ b/sample.compose.yml
@@ -35,7 +35,7 @@ services:
 
       # Environment specific values. Please consult the main manual
       SWIYU_STATUS_REGISTRY_TOKEN_URL: ${SWIYU_STATUS_REGISTRY_TOKEN_URL}
-      SWIYU_STATUS_REGISTRY_API_URL: ${SWIYU_STATUS_REGISTRY_TOKEN_URL}
+      SWIYU_STATUS_REGISTRY_API_URL: ${SWIYU_STATUS_REGISTRY_API_URL}
 
       # Default settings for the application. Only change these if you know what you are doing
       LOGGING_LEVEL_CH_ADMIN_BIT_EID: DEBUG


### PR DESCRIPTION
In sample.compose.yaml the environment variable for SWIYU_STATUS_REGISTRY_API_URL is referencing SWIYU_STATUS_REGISTRY_TOKEN_URL instead of SWIYU_STATUS_REGISTRY_API_URL

This breaks the /api/v1/status-list endpoint, as described in #2 

If you don't fix the issue, you should at least re-open #2 so that it can be found easily.