### PR TITLE
Dockerfile Update: Expose Port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN set -uxe && \
     chmod g=u /app/entrypoint.sh &&\
     chmod +x /app/entrypoint.sh
 
+EXPOSE 8080
+
 WORKDIR /app
 
 USER 1001


### PR DESCRIPTION
Added **EXPOSE 8080** to the Dockerfile to explicitly declare the application’s listening port.

This makes it clearer for anyone running the container or using orchestration tools (like Kubernetes or Docker Compose) that the app runs on port 8080.

Let me know if you’d like this port parameterized or documented further.